### PR TITLE
fix(archive): report what the push did, not what it hoped for

### DIFF
--- a/claudius-maximus-container/archive-email.sh
+++ b/claudius-maximus-container/archive-email.sh
@@ -194,7 +194,18 @@ push_archive() {
 
   git -C "${ARCHIVE_DIR}" add -A
   git -C "${ARCHIVE_DIR}" commit -m "archive: ${count} email(s) — $(date -u '+%Y-%m-%d %H:%M UTC')" 2>/dev/null || return 0
-  git -C "${ARCHIVE_DIR}" push 2>/dev/null \
-    || log "archive: WARNING — push failed (will retry next cycle)"
-  log "archive: Pushed ${count} email(s) to ${ARCHIVE_REPO}"
+  # Report what happened, not what was hoped for. The success line used to sit
+  # outside the || branch, so a failed push logged a warning and then announced
+  # success anyway -- and 2>/dev/null ate the reason. Every push failed for six
+  # months (no credential: gh reads GH_TOKEN from the env, plain git does not)
+  # while the log said "Pushed N email(s)" each time.
+  local push_err
+  if push_err=$(git -C "${ARCHIVE_DIR}" push 2>&1); then
+    log "archive: pushed ${count} email(s) to ${ARCHIVE_REPO}"
+  else
+    # Whole error on one line, not a slice of it: git puts the actionable line
+    # FIRST ("fatal: could not read Username...") and boilerplate last, so taking
+    # the last line reliably reports the least useful part.
+    log "archive: WARNING — push FAILED (retrying next cycle): $(printf '%s' "${push_err}" | tr '\n' ' ' | cut -c1-300)"
+  fi
 }


### PR DESCRIPTION
## What was wrong

```bash
git -C "${ARCHIVE_DIR}" push 2>/dev/null \
  || log "archive: WARNING — push failed (will retry next cycle)"
log "archive: Pushed ${count} email(s) to ${ARCHIVE_REPO}"
```

The success line sits **outside** the `||` branch, so a failed push logs a warning and then announces success anyway. And `2>/dev/null` discards the reason.

**Every push has failed since the archive was created on 2026-02-27** — 458 commits, six months — while the log said `Pushed N email(s)` each time. `origin/main`'s newest commit was still the original backfill. Nobody looked, because the log said it was fine.

## Why the pushes failed

No credential. Setup clones with `gh` (which reads `GH_TOKEN` from the environment); the ongoing push uses plain `git` (which does not). The asymmetry was there from the first line.

Already fixed on the box, separately from this PR, with a credential helper that resolves `$GH_TOKEN` at push time rather than baking a token into `.git/config` on a shared docker volume:

```
git config --local credential.helper '!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f'
```

459 commits have since pushed; the remote now holds 1407 letters (was 118) and is private.

## The fix here

Report the outcome, and the whole error on one line. `${err##*$'\n'}` was the first attempt and it reliably reports the *least* useful part — git puts the actionable line first and boilerplate last.

## Verified — three arms, not one

| arm | expected | got |
|---|---|---|
| push succeeds | `pushed N email(s)` | ✅ |
| push fails, bad remote | `FAILED` + the `fatal:` line | ✅ |
| push fails at auth (the real six-month failure) | `FAILED` + the remote's reason | ✅ |

The third arm was **void on first run** — without `branch.main.remote`/`branch.main.merge` set, the push died on "no upstream branch" and never reached authentication, so it reported the same error as arm two. A test that cannot produce the failure cannot clear it.

## Deploy note

The box builds from `context: ./src`, and `~/apps/claudius/src` is not a git checkout — it is a copy that can drift (cf. `chore(caddy): reconcile Caddyfile with the box, which was six blocks ahead`). I verified `archive-email.sh` on the box is currently **byte-identical to `main`**, so there is nothing to reconcile. Deploy after merge — copying an unmerged file onto the box would create the drift that currently doesn't exist.

Nothing takes effect until `docker compose build claudius && docker compose up -d claudius` on imagineering.